### PR TITLE
feat: dynamically discover collection types

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,9 +80,16 @@ All collection/depot URLs are matched with `re.compile(re.escape(base_url))`.
 
 ---
 
-## Out of scope for this integration
+## Git workflow
 
-- **Periodic address re-discovery**: not implemented; reload is the intended mechanism.
+- **Squash review fixes into the original commit they fix** rather than adding separate
+  "address review" commits. If a fix belongs to a `feat` commit, amend that commit;
+  if it fixes a `fix` commit, amend that one. Use `git rebase -i` / `--fixup` as needed.
+  Force-push the branch after rebasing.
+
+---
+
+## Out of scope for this integration
 - **`async_migrate_entry`**: the config entry data/options schema is backward-compatible;
   no migration is needed (existing keys use `.get()` with defaults).
 - **Multiple config entries**: `single_config_entry: true` in `manifest.json` prevents

--- a/README.md
+++ b/README.md
@@ -7,13 +7,177 @@
 
 Intégration Home Assistant pour le service français de collecte des déchets [Ecocito](https://www.ecocito.com/).
 
-Connectez votre compte Ecocito à Home Assistant pour suivre :
-- 🗑️ Vos **collectes d'ordures** (nombre, poids total, dernière collecte)
-- ♻️ Vos **collectes de recyclage** (nombre, poids total, dernière collecte)
-- 🚗 Vos **visites en déchetterie** (nombre de visites)
+Connectez votre compte Ecocito à Home Assistant pour suivre automatiquement tous vos types de collecte :
+- 🗑️ **Ordures ménagères** (nombre, poids total, dernière collecte)
+- ♻️ **Recyclage** (nombre, poids total, dernière collecte)
+- 🌿 **Déchets verts** (nombre, poids total, dernière collecte)
+- 🚗 **Visites en déchetterie** (nombre de visites)
+- Et tout autre type de collecte exposé par votre collectivité — **découverts automatiquement**
 
 Les données couvrent l'année en cours et les années précédentes (configurable).  
-Si votre compte possède plusieurs adresses, une entité est créée par adresse.
+Si votre compte possède plusieurs adresses, un appareil distinct est créé par adresse.
+
+---
+
+## Prérequis
+
+- Home Assistant ≥ 2024.6.0
+- Un compte Ecocito actif ([ecocito.com](https://www.ecocito.com/))
+- Votre **domaine Ecocito** (ex. `69.ecocito.com` → entrez `69.ecocito.com` ou simplement `69`)
+
+---
+
+## Installation
+
+### Via HACS (recommandé)
+
+[![Ouvrir dans HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=rclsilver&repository=home-assistant-ecocito&category=integration)
+
+1. Cliquez sur le bouton ci-dessus
+2. Installez l'intégration depuis HACS
+3. Redémarrez Home Assistant
+
+### Installation manuelle
+
+1. Ouvrez le dossier de configuration de votre HA (où se trouve `configuration.yaml`)
+2. Créez le dossier `custom_components` s'il n'existe pas
+3. Créez le sous-dossier `custom_components/ecocito`
+4. Téléchargez tous les fichiers de `custom_components/ecocito/` depuis ce dépôt
+5. Copiez-les dans le dossier créé
+6. Redémarrez Home Assistant
+
+---
+
+## Configuration
+
+1. Dans HA, allez dans **Paramètres → Intégrations**
+2. Cliquez sur **Ajouter une intégration** et recherchez **Ecocito**
+3. Renseignez :
+   - **Domaine Ecocito** : votre domaine (ex. `69.ecocito.com`)
+   - **Identifiant** : votre email ou identifiant Ecocito
+   - **Mot de passe** : votre mot de passe Ecocito
+
+### Options (après configuration)
+
+Via **Paramètres → Intégrations → Ecocito → Configurer** :
+
+| Option | Défaut | Description |
+|--------|--------|-------------|
+| **Années d'historique** | 2 | Nombre d'années précédentes à afficher (0–5) |
+
+---
+
+## Entités créées
+
+> Les types de collecte sont **découverts automatiquement** depuis votre espace Ecocito.  
+> Un capteur est créé pour chaque type exposé par votre collectivité — aucune configuration manuelle n'est nécessaire.  
+> Si de nouveaux types apparaissent, l'intégration se recharge automatiquement pour les inclure.
+
+Pour chaque type de collecte et chaque adresse de votre compte, les capteurs suivants sont créés.
+
+### Année en cours
+
+| Entité | Unité | Description |
+|--------|-------|-------------|
+| Nombre de collectes `<type>` | — | Nombre total de collectes |
+| Poids total collecté `<type>` | kg | Poids cumulé |
+| Poids de la dernière collecte `<type>` | kg | Poids lors de la dernière collecte |
+| Nombre de visites en déchetterie | — | Nombre de visites effectuées |
+
+### Années précédentes _(suffixées `(N-n)`, selon la configuration)_
+
+| Entité | Unité |
+|--------|-------|
+| Nombre de collectes `<type>` (N-n) | — |
+| Poids total collecté `<type>` (N-n) | kg |
+| Nombre de visites en déchetterie (N-n) | — |
+
+### IDs d'entités
+
+Les IDs sont toujours générés en **anglais**, quelle que soit la langue de votre instance HA.  
+Les libellés affichés sont dans la langue de votre instance.
+
+---
+
+## Exemples d'automatisations
+
+### Notification lors d'une nouvelle collecte
+
+```yaml
+automation:
+  - alias: "Notification collecte d'ordures"
+    trigger:
+      - platform: state
+        entity_id: sensor.ecocito_number_of_garbage_collections
+    action:
+      - service: notify.mobile_app
+        data:
+          message: >
+            Nouvelle collecte enregistrée !
+            Total cette année : {{ states('sensor.ecocito_number_of_garbage_collections') }} collectes
+            pour {{ states('sensor.ecocito_total_weight_of_collected_garbage') }} kg.
+```
+
+### Affichage dans un dashboard Lovelace
+
+```yaml
+type: entities
+title: Ecocito — Déchets
+entities:
+  - entity: sensor.ecocito_number_of_garbage_collections
+  - entity: sensor.ecocito_total_weight_of_collected_garbage
+  - entity: sensor.ecocito_weight_of_the_latest_garbage_collection
+  - entity: sensor.ecocito_number_of_recycling_collections
+  - entity: sensor.ecocito_total_weight_of_collected_recycling
+  - entity: sensor.ecocito_number_of_visits_to_waste_deposit
+```
+
+---
+
+## Dépannage
+
+### Les capteurs affichent "Indisponible"
+
+- Vérifiez que votre identifiant et mot de passe sont corrects
+- Vérifiez que votre domaine Ecocito est correct (ex. `69.ecocito.com`)
+- Consultez les logs HA : **Paramètres → Système → Journaux** et cherchez `ecocito`
+
+### Les données ne se mettent pas à jour
+
+- Les données sont rafraîchies toutes les **5 minutes**
+- En cas d'erreur réseau, l'intégration réessaie jusqu'à 3 fois automatiquement
+- Si la session expire, une ré-authentification automatique est tentée
+
+### Un nouveau type de collecte n'apparaît pas
+
+- Les types sont vérifiés **toutes les heures**
+- Si un nouveau type est détecté, l'intégration se recharge automatiquement
+- Vous pouvez forcer la prise en compte via **Paramètres → Intégrations → Ecocito → (⋮) → Recharger**
+
+### Plusieurs adresses mais un seul appareil visible
+
+- L'intégration détecte les adresses depuis les données de collecte
+- Si vous avez récemment ajouté une adresse, attendez la prochaine mise à jour ou rechargez l'intégration
+
+### Reconfigurer les identifiants
+
+**Paramètres → Intégrations → Ecocito → (⋮) → Reconfigurer**
+
+---
+
+## Contribution
+
+Les contributions sont les bienvenues ! Consultez le [guide de contribution](CONTRIBUTING.md).
+
+---
+
+[commits-shield]: https://img.shields.io/github/commit-activity/y/rclsilver/home-assistant-ecocito.svg?style=for-the-badge
+[commits]: https://github.com/rclsilver/home-assistant-ecocito/commits/master
+[hacs-shield]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
+[hacs]: https://hacs.xyz/
+[license-shield]: https://img.shields.io/github/license/rclsilver/home-assistant-ecocito.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/rclsilver/home-assistant-ecocito.svg?style=for-the-badge
+[releases]: https://github.com/rclsilver/home-assistant-ecocito/releases
 
 ---
 

--- a/custom_components/ecocito/__init__.py
+++ b/custom_components/ecocito/__init__.py
@@ -60,7 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcocitoConfigEntry) -> b
     )
     await client.authenticate()
 
-    history_years = entry.options.get(CONF_HISTORY_YEARS, DEFAULT_HISTORY_YEARS)
+    history_years = int(entry.options.get(CONF_HISTORY_YEARS, DEFAULT_HISTORY_YEARS))
     time_zone = ZoneInfo(hass.config.time_zone)
     current_year = datetime.now(tz=time_zone).year
 

--- a/custom_components/ecocito/__init__.py
+++ b/custom_components/ecocito/__init__.py
@@ -10,11 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DOMAIN, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 
-from .client import EcocitoClient
+from .client import CollectionType, EcocitoClient
 from .const import CONF_HISTORY_YEARS, DEFAULT_HISTORY_YEARS
 from .coordinator import (
-    GarbageCollectionsDataUpdateCoordinator,
-    RecyclingCollectionsDataUpdateCoordinator,
+    CollectionEventsDataUpdateCoordinator,
+    CollectionTypesDataUpdateCoordinator,
     WasteDepotVisitsDataUpdateCoordinator,
 )
 
@@ -27,8 +27,7 @@ class EcocitoYearCoordinators:
 
     year: int
     year_offset: int
-    garbage: GarbageCollectionsDataUpdateCoordinator
-    recycling: RecyclingCollectionsDataUpdateCoordinator
+    collection_types: dict[str, CollectionEventsDataUpdateCoordinator]
     waste_depot: WasteDepotVisitsDataUpdateCoordinator
 
 
@@ -41,7 +40,15 @@ class EcocitoAddressData:
     coordinators: list[EcocitoYearCoordinators]
 
 
-type EcocitoConfigEntry = ConfigEntry[list[EcocitoAddressData]]
+@dataclass(kw_only=True, slots=True)
+class EcocitoData:
+    """All runtime data for the integration."""
+
+    collection_types_coordinator: CollectionTypesDataUpdateCoordinator
+    addresses: list[EcocitoAddressData]
+
+
+type EcocitoConfigEntry = ConfigEntry[EcocitoData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EcocitoConfigEntry) -> bool:
@@ -57,18 +64,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcocitoConfigEntry) -> b
     time_zone = ZoneInfo(hass.config.time_zone)
     current_year = datetime.now(tz=time_zone).year
 
-    addresses = await client.get_addresses(current_year)
+    # Discover all collection types from the Ecocito page. This replaces the
+    # previous hardcoded garbage (15) / recycling (16) type IDs.
+    collection_types: list[CollectionType] = await client.get_collection_types()
+
+    addresses = await client.get_addresses(current_year, collection_types)
     if not addresses:
         addresses = [None]
 
-    # Note: address discovery happens once at setup time. Adding or removing
-    # addresses on the Ecocito account requires reloading the integration to
-    # be reflected in Home Assistant.
+    # Note: address and type discovery happen once at setup time. Adding or
+    # removing addresses/types on the Ecocito account requires reloading the
+    # integration. Type changes are also detected automatically by the
+    # CollectionTypesDataUpdateCoordinator (hourly poll).
     single_address = len(addresses) <= 1
 
     # Create one WasteDepotVisitsDataUpdateCoordinator per year offset so that
-    # waste-depot visits (which are account-wide, not per address) are fetched
-    # only once per year regardless of how many addresses are configured.
+    # waste-depot visits (account-wide, not per address) are fetched only once
+    # per year regardless of how many addresses are configured.
     waste_depot_by_offset: dict[int, WasteDepotVisitsDataUpdateCoordinator] = {
         year_offset: WasteDepotVisitsDataUpdateCoordinator(hass, client, year_offset)
         for year_offset in range(0, -(history_years + 1), -1)
@@ -79,18 +91,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcocitoConfigEntry) -> b
         year_coordinators: list[EcocitoYearCoordinators] = []
         for year_offset in range(0, -(history_years + 1), -1):
             year = current_year + year_offset
-            garbage = GarbageCollectionsDataUpdateCoordinator(
-                hass, client, year_offset, location=address
-            )
-            recycling = RecyclingCollectionsDataUpdateCoordinator(
-                hass, client, year_offset, location=address
-            )
+            type_coordinators: dict[str, CollectionEventsDataUpdateCoordinator] = {
+                ctype.id: CollectionEventsDataUpdateCoordinator(
+                    hass, client, ctype, year_offset, location=address
+                )
+                for ctype in collection_types
+            }
             year_coordinators.append(
                 EcocitoYearCoordinators(
                     year=year,
                     year_offset=year_offset,
-                    garbage=garbage,
-                    recycling=recycling,
+                    collection_types=type_coordinators,
                     waste_depot=waste_depot_by_offset[year_offset],
                 )
             )
@@ -105,12 +116,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcocitoConfigEntry) -> b
     # Refresh per-address coordinators, then waste-depot ones (once per year).
     for address_data in all_address_data:
         for year_coords in address_data.coordinators:
-            await year_coords.garbage.async_config_entry_first_refresh()
-            await year_coords.recycling.async_config_entry_first_refresh()
+            for coordinator in year_coords.collection_types.values():
+                await coordinator.async_config_entry_first_refresh()
     for waste_depot in waste_depot_by_offset.values():
         await waste_depot.async_config_entry_first_refresh()
 
-    entry.runtime_data = all_address_data
+    # The collection types coordinator polls hourly and reloads the integration
+    # if the available types have changed. Seed it with the already-fetched types
+    # to avoid a redundant HTTP request on startup/reload.
+    known_type_ids = frozenset(ctype.id for ctype in collection_types)
+    types_coordinator = CollectionTypesDataUpdateCoordinator(
+        hass, client, known_type_ids
+    )
+    types_coordinator.async_set_updated_data(collection_types)
+
+    entry.runtime_data = EcocitoData(
+        collection_types_coordinator=types_coordinator,
+        addresses=all_address_data,
+    )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 

--- a/custom_components/ecocito/client.py
+++ b/custom_components/ecocito/client.py
@@ -13,13 +13,12 @@ from bs4 import BeautifulSoup as bs  # noqa: N813
 
 from .const import (
     ECOCITO_COLLECTION_ENDPOINT,
+    ECOCITO_COLLECTION_PAGE_ENDPOINT,
     ECOCITO_DEFAULT_COLLECTION_TYPE,
-    ECOCITO_GARBAGE_COLLECTION_TYPE,
     ECOCITO_LOGIN_ENDPOINT,
     ECOCITO_LOGIN_PASSWORD_KEY,
     ECOCITO_LOGIN_URI,
     ECOCITO_LOGIN_USERNAME_KEY,
-    ECOCITO_RECYCLING_COLLECTION_TYPE,
     ECOCITO_WASTE_DEPOSIT_ENDPOINT,
     LOGGER,
 )
@@ -27,6 +26,14 @@ from .errors import CannotConnectError, EcocitoError, InvalidAuthenticationError
 
 _MAX_RETRIES = 3
 _HTTP_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+
+@dataclass(kw_only=True, slots=True)
+class CollectionType:
+    """Represents a collection type (e.g., garbage, recycling)."""
+
+    id: str
+    name: str
 
 
 @dataclass(kw_only=True, slots=True)
@@ -96,6 +103,78 @@ class EcocitoClient:
                 msg = f"Cannot connect to Ecocito: {e}"
                 raise CannotConnectError(msg) from e
 
+    async def get_collection_types(self) -> list[CollectionType]:
+        """Return the list of collection types from the collection page."""
+        async with aiohttp.ClientSession(
+            cookie_jar=self._cookies, timeout=_HTTP_TIMEOUT
+        ) as session:
+            for attempt in range(_MAX_RETRIES):
+                try:
+                    async with session.get(
+                        ECOCITO_COLLECTION_PAGE_ENDPOINT.format(self._domain),
+                        raise_for_status=True,
+                    ) as response:
+                        content = await response.text()
+                except aiohttp.ClientResponseError as e:
+                    if e.status in (401, 403):
+                        msg = (
+                            f"Authentication error while fetching collection types: {e}"
+                        )
+                        raise InvalidAuthenticationError(msg) from e
+                    msg = (
+                        f"Unexpected server response while fetching"
+                        f" collection types: {e}"
+                    )
+                    raise EcocitoError(msg) from e
+                except aiohttp.ClientError as e:
+                    msg = f"Unable to get collection types: {e}"
+                    raise CannotConnectError(msg) from e
+
+                html = bs(content, "html.parser")
+
+                # Session may have expired; check for login form.
+                form = html.find("form", action=re.compile(f"{ECOCITO_LOGIN_URI}"))
+                if form:
+                    LOGGER.debug("The session has expired, re-authenticating.")
+                    await self.authenticate()
+                    if attempt == _MAX_RETRIES - 1:
+                        msg = "Max retries reached while fetching collection types"
+                        raise EcocitoError(msg) from None
+                    continue
+
+                # The collection type selector uses Filtres_IdMatiere as its
+                # identifier (name: Filtres.IdMatiere).
+                select = html.find("select", {"id": "Filtres_IdMatiere"}) or html.find(
+                    "select", {"name": "Filtres.IdMatiere"}
+                )
+                if not select:
+                    # Log all select elements found to help diagnose the issue.
+                    all_selects = html.find_all("select")
+                    LOGGER.debug(
+                        "IdMatiere select not found. All <select> elements: %s",
+                        [(s.get("id"), s.get("name")) for s in all_selects],
+                    )
+                    msg = "Cannot find collection type selector on the Ecocito page"
+                    raise EcocitoError(msg)
+
+                types = [
+                    CollectionType(id=opt["value"], name=opt.get_text(strip=True))
+                    for opt in select.find_all("option")
+                    if opt.get("value", "")
+                    not in (
+                        "",
+                        str(ECOCITO_DEFAULT_COLLECTION_TYPE),
+                    )
+                ]
+                if not types:
+                    msg = "No collection types found on the Ecocito page"
+                    raise EcocitoError(msg)
+
+                LOGGER.debug("Discovered %d collection type(s)", len(types))
+                return types
+        msg = "Max retries reached while fetching collection types"
+        raise EcocitoError(msg)
+
     async def get_collection_events(
         self, event_type: str, year: int
     ) -> list[CollectionEvent]:
@@ -162,13 +241,15 @@ class EcocitoClient:
         msg = "Max retries reached while fetching collection events"
         raise EcocitoError(msg)
 
-    async def get_garbage_collections(self, year: int) -> list[CollectionEvent]:
-        """Return the list of the garbage collections for a year."""
-        return await self.get_collection_events(ECOCITO_GARBAGE_COLLECTION_TYPE, year)
-
-    async def get_recycling_collections(self, year: int) -> list[CollectionEvent]:
-        """Return the list of the recycling collections for a year."""
-        return await self.get_collection_events(ECOCITO_RECYCLING_COLLECTION_TYPE, year)
+    async def get_addresses(
+        self, year: int, collection_types: list[CollectionType]
+    ) -> list[str]:
+        """Return sorted unique addresses from all collection types."""
+        locations: set[str] = set()
+        for ctype in collection_types:
+            events = await self.get_collection_events(ctype.id, year)
+            locations.update(event.location for event in events if event.location)
+        return sorted(locations)
 
     async def get_waste_depot_visits(self, year: int) -> list[WasteDepotVisit]:
         """Return the list of the waste depot visits for a year."""
@@ -226,13 +307,6 @@ class EcocitoClient:
                     raise EcocitoError(msg) from e
         msg = "Max retries reached while fetching waste depot visits"
         raise EcocitoError(msg)
-
-    async def get_addresses(self, year: int) -> list[str]:
-        """Return sorted unique addresses from garbage and recycling collections."""
-        garbage = await self.get_garbage_collections(year)
-        recycling = await self.get_recycling_collections(year)
-        locations = {event.location for event in garbage + recycling if event.location}
-        return sorted(locations)
 
     async def _handle_expired_session(self, content: str) -> None:
         """Re-authenticate if the session has expired, raise otherwise."""

--- a/custom_components/ecocito/const.py
+++ b/custom_components/ecocito/const.py
@@ -1,6 +1,7 @@
 """Constants for the ecocito integration."""
 
 import logging
+from dataclasses import dataclass
 
 DOMAIN = "ecocito"
 LOGGER = logging.getLogger(__package__)
@@ -30,11 +31,57 @@ ECOCITO_LOGIN_PASSWORD_KEY = "MotDePasse"  # noqa: S105
 
 # Ecocito - Collection types
 ECOCITO_DEFAULT_COLLECTION_TYPE = -1
-ECOCITO_GARBAGE_COLLECTION_TYPE = 15
-ECOCITO_RECYCLING_COLLECTION_TYPE = 16
 
-# Ecocito - Collection endpoint
+# Ecocito - Collection endpoints
+ECOCITO_COLLECTION_PAGE_ENDPOINT = f"https://{ECOCITO_DOMAIN}/Usager/Collecte"
 ECOCITO_COLLECTION_ENDPOINT = f"https://{ECOCITO_DOMAIN}/Usager/Collecte/GetCollecte"
 
 # Ecocito - Waste deposit visits
 ECOCITO_WASTE_DEPOSIT_ENDPOINT = f"https://{ECOCITO_DOMAIN}/Usager/Apport/GetApport"
+
+
+# ── Collection type hints ──────────────────────────────────────────────────────
+# Maps a regex pattern (matched case-insensitively against the API type name)
+# to a (translation_key, icon) hint used to give known types a proper icon and
+# localised sensor name.  First match wins.
+#
+# To add a new type: append a tuple (pattern, translation_key, icon).
+# If no pattern matches the API name, the generic "collection" fallback is used
+# and the raw API name is injected via the {type} translation placeholder.
+
+
+@dataclass(frozen=True)
+class CollectionTypeHint:
+    """Translation key and icon for a known collection type."""
+
+    translation_key: str
+    icon: str
+
+
+COLLECTION_TYPE_HINTS: list[tuple[str, CollectionTypeHint]] = [
+    # Household waste / ordures ménagères
+    (
+        r"ordures?\s+m[eé]nag[eè]res?|\bOM\b",
+        CollectionTypeHint(translation_key="garbage", icon="mdi:trash-can"),
+    ),
+    # Selective sorting / collecte sélective / recyclage
+    (
+        r"recyclage|tri\s+s[eé]lectif|\bCS\b",
+        CollectionTypeHint(translation_key="recycling", icon="mdi:recycle"),
+    ),
+    # Green waste / déchets verts
+    (
+        r"d[eé]chets?\s+verts?|\bDV\b",
+        CollectionTypeHint(translation_key="green_waste", icon="mdi:leaf"),
+    ),
+    # Badge / access card deposits
+    (
+        r"badge",
+        CollectionTypeHint(translation_key="badge", icon="mdi:card-account-details"),
+    ),
+]
+
+# Fallback used when no hint pattern matches the API type name.
+COLLECTION_TYPE_DEFAULT_HINT = CollectionTypeHint(
+    translation_key="collection", icon="mdi:trash-can"
+)

--- a/custom_components/ecocito/coordinator.py
+++ b/custom_components/ecocito/coordinator.py
@@ -11,14 +11,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .client import CollectionEvent, EcocitoClient, WasteDepotVisit
+from .client import CollectionEvent, CollectionType, EcocitoClient, WasteDepotVisit
 from .const import DOMAIN, LOGGER
 from .errors import CannotConnectError, EcocitoError, InvalidAuthenticationError
 
 
-class EcocitoDataUpdateCoordinator[T: list[CollectionEvent] | list[WasteDepotVisit]](
-    DataUpdateCoordinator[T], ABC
-):
+class EcocitoDataUpdateCoordinator[T: list](DataUpdateCoordinator[T], ABC):
     """Data update coordinator for the Ecocito integration."""
 
     config_entry: ConfigEntry
@@ -56,58 +54,72 @@ class EcocitoDataUpdateCoordinator[T: list[CollectionEvent] | list[WasteDepotVis
         raise NotImplementedError
 
 
-class GarbageCollectionsDataUpdateCoordinator(
+class CollectionEventsDataUpdateCoordinator(
     EcocitoDataUpdateCoordinator[list[CollectionEvent]]
 ):
-    """Garbage collections list update from Ecocito."""
+    """Collection events update for a specific collection type from Ecocito."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         client: EcocitoClient,
+        collection_type: CollectionType,
         year_offset: int,
         location: str | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, client)
+        self.collection_type = collection_type
         self._year_offset = year_offset
         self._location = location
 
     async def _fetch_data(self) -> list[CollectionEvent]:
         """Fetch the data."""
-        events = await self.client.get_garbage_collections(
-            datetime.now(tz=self._time_zone).year + self._year_offset
+        events = await self.client.get_collection_events(
+            self.collection_type.id,
+            datetime.now(tz=self._time_zone).year + self._year_offset,
         )
         if self._location is not None:
             events = [e for e in events if e.location == self._location]
         return events
 
 
-class RecyclingCollectionsDataUpdateCoordinator(
-    EcocitoDataUpdateCoordinator[list[CollectionEvent]]
+class CollectionTypesDataUpdateCoordinator(
+    EcocitoDataUpdateCoordinator[list[CollectionType]]
 ):
-    """Recycling collections list update from Ecocito."""
+    """
+    Collection types update coordinator.
+
+    Polls the Ecocito page hourly and triggers an integration reload if the
+    available collection types have changed since the last setup.
+    """
 
     def __init__(
         self,
         hass: HomeAssistant,
         client: EcocitoClient,
-        year_offset: int,
-        location: str | None = None,
+        known_type_ids: frozenset[str],
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(hass, client)
-        self._year_offset = year_offset
-        self._location = location
+        self.update_interval = timedelta(hours=1)
+        self._known_type_ids = known_type_ids
 
-    async def _fetch_data(self) -> list[CollectionEvent]:
-        """Fetch the data."""
-        events = await self.client.get_recycling_collections(
-            datetime.now(tz=self._time_zone).year + self._year_offset
-        )
-        if self._location is not None:
-            events = [e for e in events if e.location == self._location]
-        return events
+    async def _fetch_data(self) -> list[CollectionType]:
+        """Fetch the collection types and reload if they have changed."""
+        types = await self.client.get_collection_types()
+        current_ids = frozenset(t.id for t in types)
+        if current_ids != self._known_type_ids:
+            LOGGER.info(
+                "Collection types changed (was %s, now %s), reloading integration",
+                self._known_type_ids,
+                current_ids,
+            )
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            )
+            self._known_type_ids = current_ids
+        return types
 
 
 class WasteDepotVisitsDataUpdateCoordinator(

--- a/custom_components/ecocito/entity.py
+++ b/custom_components/ecocito/entity.py
@@ -59,3 +59,13 @@ class EcocitoEntity[T](CoordinatorEntity[EcocitoDataUpdateCoordinator[T]]):
             model=DEVICE_MODEL,
             identifiers={(DOMAIN, identifier)},
         )
+        # Keep track of the full device name for stable entity ID generation.
+        self._device_name = f"{DEVICE_NAME}{device_suffix}"
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Return a stable, language-independent object ID using English names."""
+        english_name = getattr(self.entity_description, "english_name", None)
+        if english_name:
+            return f"{self._device_name} {english_name}"
+        return super().suggested_object_id

--- a/custom_components/ecocito/sensor.py
+++ b/custom_components/ecocito/sensor.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
+import functools
+import json
+import pathlib
+import re
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -18,9 +23,49 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import EcocitoConfigEntry
-from .client import CollectionEvent, EcocitoEvent
-from .const import DEVICE_ATTRIBUTION
+from .client import CollectionEvent, CollectionType, EcocitoEvent
+from .const import (
+    COLLECTION_TYPE_DEFAULT_HINT,
+    COLLECTION_TYPE_HINTS,
+    DEVICE_ATTRIBUTION,
+    CollectionTypeHint,
+)
 from .entity import EcocitoEntity
+
+
+@functools.lru_cache(maxsize=1)
+def _get_english_sensor_names() -> dict[str, str]:
+    """Lazily load and cache English sensor names from strings.json."""
+    try:
+        data = json.loads((pathlib.Path(__file__).parent / "strings.json").read_text())
+        return {
+            k: v.get("name", k)
+            for k, v in data.get("entity", {}).get("sensor", {}).items()
+        }
+    except (OSError, ValueError):
+        return {}
+
+
+def _english_name(translation_key: str, placeholders: dict | None) -> str:
+    """Return the English name for a translation key with placeholders resolved."""
+    name = _get_english_sensor_names().get(translation_key, translation_key)
+    if placeholders:
+        with contextlib.suppress(KeyError, ValueError):
+            name = name.format(**placeholders)
+    return name
+
+
+def _resolve_collection_type_hint(name: str) -> CollectionTypeHint:
+    """
+    Return the hint (translation key + icon) for a collection type name.
+
+    Iterates COLLECTION_TYPE_HINTS in order; the first matching pattern wins.
+    Falls back to COLLECTION_TYPE_DEFAULT_HINT for unknown types.
+    """
+    for pattern, hint in COLLECTION_TYPE_HINTS:
+        if re.search(pattern, name, re.IGNORECASE):
+            return hint
+    return COLLECTION_TYPE_DEFAULT_HINT
 
 
 def get_count(data: list[Any]) -> int:
@@ -62,164 +107,127 @@ class EcocitoSensorEntityDescription[T](SensorEntityDescription):
 
     value_fn: Callable[[T], StateType] = dataclasses.field(default=None)  # type: ignore[assignment]
     last_updated_fn: Callable[[T], datetime | None] = dataclasses.field(default=None)  # type: ignore[assignment]
+    # Stable English name used for entity ID generation (independent of HA language).
+    english_name: str = dataclasses.field(default="")
 
 
-def _build_sensor_descriptions(
+def _build_collection_type_sensor_descriptions(
+    collection_type: CollectionType,
     year_offset: int,
-) -> list[tuple[str, EcocitoSensorEntityDescription]]:
-    """Build sensor entity descriptions for a given year offset."""
+) -> list[EcocitoSensorEntityDescription]:
+    """Build sensor entity descriptions for a given collection type and year offset."""
+    type_id = collection_type.id
+    hint = _resolve_collection_type_hint(collection_type.name)
+    type_key = hint.translation_key
+    icon = hint.icon
+
+    # For known types (specific translation key), no {type} placeholder needed.
+    # For unknown types (generic "collection" key), inject the raw name.
+    is_generic = type_key == COLLECTION_TYPE_DEFAULT_HINT.translation_key
+    type_placeholders = {"type": collection_type.name} if is_generic else None
+
     if year_offset == 0:
+        count_key = f"{type_key}_count"
+        total_key = f"{type_key}_total"
+        latest_key = (
+            "latest_collection" if is_generic else f"latest_{type_key}_collection"
+        )
         return [
-            (
-                "garbage",
-                EcocitoSensorEntityDescription(
-                    key="garbage_collections_count",
-                    translation_key="garbage_collections_count",
-                    value_fn=get_count,
-                    last_updated_fn=get_latest_date,
-                    icon="mdi:trash-can",
-                    state_class=SensorStateClass.TOTAL,
-                ),
+            EcocitoSensorEntityDescription(
+                key=f"collection_count_{type_id}",
+                translation_key=count_key,
+                translation_placeholders=type_placeholders,
+                english_name=_english_name(count_key, type_placeholders),
+                value_fn=get_count,
+                last_updated_fn=get_latest_date,
+                icon=icon,
+                state_class=SensorStateClass.TOTAL,
             ),
-            (
-                "garbage",
-                EcocitoSensorEntityDescription(
-                    key="garbage_collections_total",
-                    translation_key="garbage_collections_total",
-                    icon="mdi:trash-can",
-                    value_fn=get_event_collections_weight,
-                    last_updated_fn=get_latest_date,
-                    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                    state_class=SensorStateClass.TOTAL,
-                    suggested_display_precision=0,
-                ),
+            EcocitoSensorEntityDescription(
+                key=f"collection_total_{type_id}",
+                translation_key=total_key,
+                translation_placeholders=type_placeholders,
+                english_name=_english_name(total_key, type_placeholders),
+                icon=icon,
+                value_fn=get_event_collections_weight,
+                last_updated_fn=get_latest_date,
+                native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+                state_class=SensorStateClass.TOTAL,
+                suggested_display_precision=0,
             ),
-            (
-                "garbage",
-                EcocitoSensorEntityDescription(
-                    key="latest_garbage_collections",
-                    translation_key="latest_garbage_collection",
-                    icon="mdi:trash-can",
-                    value_fn=get_latest_event_collection_weight,
-                    last_updated_fn=get_latest_date,
-                    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    suggested_display_precision=0,
-                ),
-            ),
-            (
-                "recycling",
-                EcocitoSensorEntityDescription(
-                    key="recycling_collections_count",
-                    translation_key="recycling_collections_count",
-                    icon="mdi:recycle",
-                    value_fn=get_count,
-                    last_updated_fn=get_latest_date,
-                    state_class=SensorStateClass.TOTAL,
-                ),
-            ),
-            (
-                "recycling",
-                EcocitoSensorEntityDescription(
-                    key="recycling_collections_total",
-                    translation_key="recycling_collections_total",
-                    icon="mdi:recycle",
-                    value_fn=get_event_collections_weight,
-                    last_updated_fn=get_latest_date,
-                    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                    state_class=SensorStateClass.TOTAL,
-                    suggested_display_precision=0,
-                ),
-            ),
-            (
-                "recycling",
-                EcocitoSensorEntityDescription(
-                    key="latest_recycling_collections",
-                    translation_key="latest_recycling_collection",
-                    icon="mdi:recycle",
-                    value_fn=get_latest_event_collection_weight,
-                    last_updated_fn=get_latest_date,
-                    native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                    state_class=SensorStateClass.MEASUREMENT,
-                    suggested_display_precision=0,
-                ),
-            ),
-            (
-                "waste_depot",
-                EcocitoSensorEntityDescription(
-                    key="waste_deposit_visit",
-                    translation_key="waste_deposit_visit",
-                    icon="mdi:car",
-                    value_fn=get_count,
-                    last_updated_fn=get_latest_date,
-                    state_class=SensorStateClass.TOTAL,
-                ),
+            EcocitoSensorEntityDescription(
+                key=f"latest_collection_{type_id}",
+                translation_key=latest_key,
+                translation_placeholders=type_placeholders,
+                english_name=_english_name(latest_key, type_placeholders),
+                icon=icon,
+                value_fn=get_latest_event_collection_weight,
+                last_updated_fn=get_latest_date,
+                native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
             ),
         ]
+    n = abs(year_offset)
+    n_placeholders = (
+        {"n": str(n)} if not is_generic else {"type": collection_type.name, "n": str(n)}
+    )
+    count_n_key = f"{type_key}_count_n"
+    total_n_key = f"{type_key}_total_n"
     return [
-        (
-            "garbage",
-            EcocitoSensorEntityDescription(
-                key=f"garbage_collections_count_n{abs(year_offset)}",
-                translation_key="garbage_collections_count_n",
-                translation_placeholders={"n": str(abs(year_offset))},
-                value_fn=get_count,
-                last_updated_fn=get_latest_date,
-                icon="mdi:trash-can",
-                state_class=SensorStateClass.TOTAL,
-            ),
+        EcocitoSensorEntityDescription(
+            key=f"collection_count_{type_id}_n{n}",
+            translation_key=count_n_key,
+            translation_placeholders=n_placeholders,
+            english_name=_english_name(count_n_key, n_placeholders),
+            value_fn=get_count,
+            last_updated_fn=get_latest_date,
+            icon=icon,
+            state_class=SensorStateClass.TOTAL,
         ),
-        (
-            "garbage",
-            EcocitoSensorEntityDescription(
-                key=f"garbage_collections_total_n{abs(year_offset)}",
-                translation_key="garbage_collections_total_n",
-                translation_placeholders={"n": str(abs(year_offset))},
-                icon="mdi:trash-can",
-                value_fn=get_event_collections_weight,
-                last_updated_fn=get_latest_date,
-                native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                state_class=SensorStateClass.TOTAL,
-                suggested_display_precision=0,
-            ),
+        EcocitoSensorEntityDescription(
+            key=f"collection_total_{type_id}_n{n}",
+            translation_key=total_n_key,
+            translation_placeholders=n_placeholders,
+            english_name=_english_name(total_n_key, n_placeholders),
+            icon=icon,
+            value_fn=get_event_collections_weight,
+            last_updated_fn=get_latest_date,
+            native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+            state_class=SensorStateClass.TOTAL,
+            suggested_display_precision=0,
         ),
-        (
-            "recycling",
+    ]
+
+
+def _build_waste_depot_sensor_descriptions(
+    year_offset: int,
+) -> list[EcocitoSensorEntityDescription]:
+    """Build waste depot sensor entity descriptions for a given year offset."""
+    if year_offset == 0:
+        return [
             EcocitoSensorEntityDescription(
-                key=f"recycling_collections_count_n{abs(year_offset)}",
-                translation_key="recycling_collections_count_n",
-                translation_placeholders={"n": str(abs(year_offset))},
-                icon="mdi:recycle",
-                value_fn=get_count,
-                last_updated_fn=get_latest_date,
-                state_class=SensorStateClass.TOTAL,
-            ),
-        ),
-        (
-            "recycling",
-            EcocitoSensorEntityDescription(
-                key=f"recycling_collections_total_n{abs(year_offset)}",
-                translation_key="recycling_collections_total_n",
-                translation_placeholders={"n": str(abs(year_offset))},
-                icon="mdi:recycle",
-                value_fn=get_event_collections_weight,
-                last_updated_fn=get_latest_date,
-                native_unit_of_measurement=UnitOfMass.KILOGRAMS,
-                state_class=SensorStateClass.TOTAL,
-                suggested_display_precision=0,
-            ),
-        ),
-        (
-            "waste_depot",
-            EcocitoSensorEntityDescription(
-                key=f"waste_deposit_visit_n{abs(year_offset)}",
-                translation_key="waste_deposit_visit_n",
-                translation_placeholders={"n": str(abs(year_offset))},
+                key="waste_deposit_visit",
+                translation_key="waste_deposit_visit",
+                english_name=_english_name("waste_deposit_visit", None),
                 icon="mdi:car",
                 value_fn=get_count,
                 last_updated_fn=get_latest_date,
                 state_class=SensorStateClass.TOTAL,
             ),
+        ]
+    return [
+        EcocitoSensorEntityDescription(
+            key=f"waste_deposit_visit_n{abs(year_offset)}",
+            translation_key="waste_deposit_visit_n",
+            translation_placeholders={"n": str(abs(year_offset))},
+            english_name=_english_name(
+                "waste_deposit_visit_n", {"n": str(abs(year_offset))}
+            ),
+            icon="mdi:car",
+            value_fn=get_count,
+            last_updated_fn=get_latest_date,
+            state_class=SensorStateClass.TOTAL,
         ),
     ]
 
@@ -255,23 +263,24 @@ async def async_setup_entry(
     # Waste-depot visits are account-wide (not per address), so the coordinator
     # is shared across all addresses for a given year; only add its sensors once.
     registered_waste_depot: set[int] = set()
-    for address_data in entry.runtime_data:
+    for address_data in entry.runtime_data.addresses:
         location = address_data.location if not address_data.single_address else None
         for year_coords in address_data.coordinators:
-            for coord_attr, description in _build_sensor_descriptions(
-                year_coords.year_offset
-            ):
-                coordinator = getattr(year_coords, coord_attr)
-                if coord_attr == "waste_depot":
-                    coord_id = id(coordinator)
-                    if coord_id in registered_waste_depot:
-                        continue
-                    registered_waste_depot.add(coord_id)
-                    entities.append(
-                        EcocitoSensor(coordinator, description, location=None)
+            for coordinator in year_coords.collection_types.values():
+                entities.extend(
+                    EcocitoSensor(coordinator, description, location=location)
+                    for description in _build_collection_type_sensor_descriptions(
+                        coordinator.collection_type, year_coords.year_offset
                     )
-                else:
-                    entities.append(
-                        EcocitoSensor(coordinator, description, location=location)
+                )
+            waste_depot = year_coords.waste_depot
+            coord_id = id(waste_depot)
+            if coord_id not in registered_waste_depot:
+                registered_waste_depot.add(coord_id)
+                entities.extend(
+                    EcocitoSensor(waste_depot, description, location=None)
+                    for description in _build_waste_depot_sensor_descriptions(
+                        year_coords.year_offset
                     )
+                )
     async_add_entities(entities)

--- a/custom_components/ecocito/strings.json
+++ b/custom_components/ecocito/strings.json
@@ -33,38 +33,83 @@
   },
   "entity": {
     "sensor": {
-      "garbage_collections_count": {
+      "garbage_count": {
         "name": "Number of garbage collections"
       },
-      "garbage_collections_total": {
+      "garbage_total": {
         "name": "Total weight of collected garbage"
       },
       "latest_garbage_collection": {
         "name": "Weight of the latest garbage collection"
       },
-      "recycling_collections_count": {
+      "garbage_count_n": {
+        "name": "Number of garbage collections (N-{n})"
+      },
+      "garbage_total_n": {
+        "name": "Total weight of collected garbage (N-{n})"
+      },
+      "recycling_count": {
         "name": "Number of recycling collections"
       },
-      "recycling_collections_total": {
+      "recycling_total": {
         "name": "Total weight of collected recycling"
       },
       "latest_recycling_collection": {
         "name": "Weight of the latest recycling collection"
       },
-      "waste_deposit_visit": {
-        "name": "Number of visits to waste deposit"
-      },
-      "garbage_collections_count_n": {
-        "name": "Number of garbage collections (N-{n})"
-      },
-      "garbage_collections_total_n": {
-        "name": "Total weight of collected garbage (N-{n})"
-      },
-      "recycling_collections_count_n": {
+      "recycling_count_n": {
         "name": "Number of recycling collections (N-{n})"
       },
-      "recycling_collections_total_n": {
+      "recycling_total_n": {
         "name": "Total weight of collected recycling (N-{n})"
+      },
+      "green_waste_count": {
+        "name": "Number of green waste collections"
+      },
+      "green_waste_total": {
+        "name": "Total weight of collected green waste"
+      },
+      "latest_green_waste_collection": {
+        "name": "Weight of the latest green waste collection"
+      },
+      "green_waste_count_n": {
+        "name": "Number of green waste collections (N-{n})"
+      },
+      "green_waste_total_n": {
+        "name": "Total weight of collected green waste (N-{n})"
+      },
+      "badge_count": {
+        "name": "Number of badge collections"
+      },
+      "badge_total": {
+        "name": "Total weight of collected badge"
+      },
+      "latest_badge_collection": {
+        "name": "Weight of the latest badge collection"
+      },
+      "badge_count_n": {
+        "name": "Number of badge collections (N-{n})"
+      },
+      "badge_total_n": {
+        "name": "Total weight of collected badge (N-{n})"
+      },
+      "collection_count": {
+        "name": "Number of {type} collections"
+      },
+      "collection_total": {
+        "name": "Total weight of collected {type}"
+      },
+      "latest_collection": {
+        "name": "Weight of the latest {type} collection"
+      },
+      "collection_count_n": {
+        "name": "Number of {type} collections (N-{n})"
+      },
+      "collection_total_n": {
+        "name": "Total weight of collected {type} (N-{n})"
+      },
+      "waste_deposit_visit": {
+        "name": "Number of visits to waste deposit"
       },
       "waste_deposit_visit_n": {
         "name": "Number of visits to waste deposit (N-{n})"

--- a/custom_components/ecocito/translations/en.json
+++ b/custom_components/ecocito/translations/en.json
@@ -33,38 +33,83 @@
   },
   "entity": {
     "sensor": {
-      "garbage_collections_count": {
+      "garbage_count": {
         "name": "Number of garbage collections"
       },
-      "garbage_collections_total": {
+      "garbage_total": {
         "name": "Total weight of collected garbage"
       },
       "latest_garbage_collection": {
         "name": "Weight of the latest garbage collection"
       },
-      "recycling_collections_count": {
+      "garbage_count_n": {
+        "name": "Number of garbage collections (N-{n})"
+      },
+      "garbage_total_n": {
+        "name": "Total weight of collected garbage (N-{n})"
+      },
+      "recycling_count": {
         "name": "Number of recycling collections"
       },
-      "recycling_collections_total": {
+      "recycling_total": {
         "name": "Total weight of collected recycling"
       },
       "latest_recycling_collection": {
         "name": "Weight of the latest recycling collection"
       },
-      "waste_deposit_visit": {
-        "name": "Number of visits to waste deposit"
-      },
-      "garbage_collections_count_n": {
-        "name": "Number of garbage collections (N-{n})"
-      },
-      "garbage_collections_total_n": {
-        "name": "Total weight of collected garbage (N-{n})"
-      },
-      "recycling_collections_count_n": {
+      "recycling_count_n": {
         "name": "Number of recycling collections (N-{n})"
       },
-      "recycling_collections_total_n": {
+      "recycling_total_n": {
         "name": "Total weight of collected recycling (N-{n})"
+      },
+      "green_waste_count": {
+        "name": "Number of green waste collections"
+      },
+      "green_waste_total": {
+        "name": "Total weight of collected green waste"
+      },
+      "latest_green_waste_collection": {
+        "name": "Weight of the latest green waste collection"
+      },
+      "green_waste_count_n": {
+        "name": "Number of green waste collections (N-{n})"
+      },
+      "green_waste_total_n": {
+        "name": "Total weight of collected green waste (N-{n})"
+      },
+      "badge_count": {
+        "name": "Number of badge collections"
+      },
+      "badge_total": {
+        "name": "Total weight of collected badge"
+      },
+      "latest_badge_collection": {
+        "name": "Weight of the latest badge collection"
+      },
+      "badge_count_n": {
+        "name": "Number of badge collections (N-{n})"
+      },
+      "badge_total_n": {
+        "name": "Total weight of collected badge (N-{n})"
+      },
+      "collection_count": {
+        "name": "Number of {type} collections"
+      },
+      "collection_total": {
+        "name": "Total weight of collected {type}"
+      },
+      "latest_collection": {
+        "name": "Weight of the latest {type} collection"
+      },
+      "collection_count_n": {
+        "name": "Number of {type} collections (N-{n})"
+      },
+      "collection_total_n": {
+        "name": "Total weight of collected {type} (N-{n})"
+      },
+      "waste_deposit_visit": {
+        "name": "Number of visits to waste deposit"
       },
       "waste_deposit_visit_n": {
         "name": "Number of visits to waste deposit (N-{n})"

--- a/custom_components/ecocito/translations/fr.json
+++ b/custom_components/ecocito/translations/fr.json
@@ -33,38 +33,83 @@
   },
   "entity": {
     "sensor": {
-      "garbage_collections_count": {
-        "name": "Nombre de collectes d'ordures"
+      "garbage_count": {
+        "name": "Nombre de collectes d'ordures ménagères"
       },
-      "garbage_collections_total": {
-        "name": "Poids total des ordures collectées"
+      "garbage_total": {
+        "name": "Poids total des ordures ménagères collectées"
       },
       "latest_garbage_collection": {
-        "name": "Poids de la dernière collecte d'ordures"
+        "name": "Poids de la dernière collecte d'ordures ménagères"
       },
-      "recycling_collections_count": {
+      "garbage_count_n": {
+        "name": "Nombre de collectes d'ordures ménagères (N-{n})"
+      },
+      "garbage_total_n": {
+        "name": "Poids total des ordures ménagères collectées (N-{n})"
+      },
+      "recycling_count": {
         "name": "Nombre de collectes de recyclage"
       },
-      "recycling_collections_total": {
+      "recycling_total": {
         "name": "Poids total du recyclage collecté"
       },
       "latest_recycling_collection": {
         "name": "Poids de la dernière collecte de recyclage"
       },
-      "waste_deposit_visit": {
-        "name": "Nombre de visites en déchetterie"
-      },
-      "garbage_collections_count_n": {
-        "name": "Nombre de collectes d'ordures (N-{n})"
-      },
-      "garbage_collections_total_n": {
-        "name": "Poids total des ordures collectées (N-{n})"
-      },
-      "recycling_collections_count_n": {
+      "recycling_count_n": {
         "name": "Nombre de collectes de recyclage (N-{n})"
       },
-      "recycling_collections_total_n": {
+      "recycling_total_n": {
         "name": "Poids total du recyclage collecté (N-{n})"
+      },
+      "green_waste_count": {
+        "name": "Nombre de collectes de déchets verts"
+      },
+      "green_waste_total": {
+        "name": "Poids total des déchets verts collectés"
+      },
+      "latest_green_waste_collection": {
+        "name": "Poids de la dernière collecte de déchets verts"
+      },
+      "green_waste_count_n": {
+        "name": "Nombre de collectes de déchets verts (N-{n})"
+      },
+      "green_waste_total_n": {
+        "name": "Poids total des déchets verts collectés (N-{n})"
+      },
+      "badge_count": {
+        "name": "Nombre de collectes badge"
+      },
+      "badge_total": {
+        "name": "Poids total des collectes badge"
+      },
+      "latest_badge_collection": {
+        "name": "Poids de la dernière collecte badge"
+      },
+      "badge_count_n": {
+        "name": "Nombre de collectes badge (N-{n})"
+      },
+      "badge_total_n": {
+        "name": "Poids total des collectes badge (N-{n})"
+      },
+      "collection_count": {
+        "name": "Nombre de collectes {type}"
+      },
+      "collection_total": {
+        "name": "Poids total collecté {type}"
+      },
+      "latest_collection": {
+        "name": "Poids de la dernière collecte {type}"
+      },
+      "collection_count_n": {
+        "name": "Nombre de collectes {type} (N-{n})"
+      },
+      "collection_total_n": {
+        "name": "Poids total collecté {type} (N-{n})"
+      },
+      "waste_deposit_visit": {
+        "name": "Nombre de visites en déchetterie"
       },
       "waste_deposit_visit_n": {
         "name": "Nombre de visites en déchetterie (N-{n})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,11 @@ from homeassistant.core import HassJob
 from homeassistant.util.async_ import get_scheduled_timer_handles
 from pytest_homeassistant_custom_component.common import INSTANCES
 
-from custom_components.ecocito.client import CollectionEvent, WasteDepotVisit
-from custom_components.ecocito.const import ECOCITO_GARBAGE_COLLECTION_TYPE
+from custom_components.ecocito.client import (
+    CollectionEvent,
+    CollectionType,
+    WasteDepotVisit,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -96,11 +99,20 @@ def mock_client() -> MagicMock:
     """Return a mocked EcocitoClient with async methods returning empty data."""
     client = MagicMock()
     client.authenticate = AsyncMock()
-    client.get_garbage_collections = AsyncMock(return_value=[])
-    client.get_recycling_collections = AsyncMock(return_value=[])
+    client.get_collection_types = AsyncMock(return_value=[])
+    client.get_collection_events = AsyncMock(return_value=[])
     client.get_waste_depot_visits = AsyncMock(return_value=[])
     client.get_addresses = AsyncMock(return_value=[])
     return client
+
+
+@pytest.fixture
+def sample_collection_types() -> list[CollectionType]:
+    """Return a list of 2 sample CollectionType instances."""
+    return [
+        CollectionType(id="15", name="Ordures ménagères"),
+        CollectionType(id="16", name="Recyclage"),
+    ]
 
 
 @pytest.fixture
@@ -110,13 +122,13 @@ def sample_collection_events() -> list[CollectionEvent]:
         CollectionEvent(
             date=datetime(2024, 3, 15, tzinfo=UTC),
             location="12 rue de la Paix",
-            type=str(ECOCITO_GARBAGE_COLLECTION_TYPE),
+            type="15",
             quantity=120.0,
         ),
         CollectionEvent(
             date=datetime(2024, 3, 29, tzinfo=UTC),
             location="12 rue de la Paix",
-            type=str(ECOCITO_GARBAGE_COLLECTION_TYPE),
+            type="15",
             quantity=80.0,
         ),
     ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,12 +11,13 @@ from yarl import URL
 
 from custom_components.ecocito.client import (
     CollectionEvent,
+    CollectionType,
     EcocitoClient,
     WasteDepotVisit,
 )
 from custom_components.ecocito.const import (
     ECOCITO_COLLECTION_ENDPOINT,
-    ECOCITO_GARBAGE_COLLECTION_TYPE,
+    ECOCITO_COLLECTION_PAGE_ENDPOINT,
     ECOCITO_LOGIN_ENDPOINT,
     ECOCITO_WASTE_DEPOSIT_ENDPOINT,
 )
@@ -29,10 +30,12 @@ from custom_components.ecocito.errors import (
 _TEST_SUBDOMAIN = "test"
 _LOGIN_URL = ECOCITO_LOGIN_ENDPOINT.format(_TEST_SUBDOMAIN)
 _COLLECTION_URL = ECOCITO_COLLECTION_ENDPOINT.format(_TEST_SUBDOMAIN)
+_COLLECTION_PAGE_URL = ECOCITO_COLLECTION_PAGE_ENDPOINT.format(_TEST_SUBDOMAIN)
 _WASTE_DEPOT_URL = ECOCITO_WASTE_DEPOSIT_ENDPOINT.format(_TEST_SUBDOMAIN)
 
 # Regex patterns to match URLs regardless of query params
 _COLLECTION_RE = re.compile(re.escape(_COLLECTION_URL))
+_COLLECTION_PAGE_RE = re.compile(re.escape(_COLLECTION_PAGE_URL))
 _WASTE_DEPOT_RE = re.compile(re.escape(_WASTE_DEPOT_URL))
 
 _VALID_COLLECTION_JSON = {
@@ -59,6 +62,15 @@ _HTML_INVALID_CREDENTIALS = (
     '<div class="validation-summary-errors">'
     "<ul><li>Identifiants invalides</li></ul>"
     "</div></body></html>"
+)
+_HTML_COLLECTION_PAGE = (
+    "<html><body>"
+    '<select id="Filtres_IdMatiere" name="Filtres.IdMatiere">'
+    '<option value="-1">Tous les types de déchets</option>'
+    '<option value="15">Ordures ménagères</option>'
+    '<option value="16">Recyclage</option>'
+    "</select>"
+    "</body></html>"
 )
 
 
@@ -103,15 +115,55 @@ async def test_authenticate_network_error() -> None:
             await client.authenticate()
 
 
+async def test_get_collection_types_success() -> None:
+    """GET collection page with select → list of CollectionType (excluding -1)."""
+    client = _make_client()
+    _populate_cookies(client)
+    with aioresponses() as m:
+        m.get(_COLLECTION_PAGE_RE, status=200, body=_HTML_COLLECTION_PAGE.encode())
+        types = await client.get_collection_types()
+
+    assert len(types) == 2
+    assert isinstance(types[0], CollectionType)
+    assert types[0].id == "15"
+    assert types[0].name == "Ordures ménagères"
+    assert types[1].id == "16"
+    assert types[1].name == "Recyclage"
+
+
+async def test_get_collection_types_session_expired() -> None:
+    """First GET returns login HTML → re-auth → second GET returns page."""
+    client = _make_client()
+    _populate_cookies(client)
+    with aioresponses() as m:
+        m.get(_COLLECTION_PAGE_RE, status=200, body=_HTML_LOGIN_FORM.encode())
+        m.post(_LOGIN_URL, status=200, body=_HTML_SUCCESS.encode())
+        m.get(_COLLECTION_PAGE_RE, status=200, body=_HTML_COLLECTION_PAGE.encode())
+        types = await client.get_collection_types()
+
+    assert len(types) == 2
+
+
+async def test_get_collection_types_network_error() -> None:
+    """GET raises aiohttp.ClientError → CannotConnectError."""
+    client = _make_client()
+    _populate_cookies(client)
+    with aioresponses() as m:
+        m.get(
+            _COLLECTION_PAGE_RE,
+            exception=aiohttp.ClientConnectionError("network failure"),
+        )
+        with pytest.raises(CannotConnectError):
+            await client.get_collection_types()
+
+
 async def test_get_collection_events_success() -> None:
     """GET returns valid JSON → list of CollectionEvent."""
     client = _make_client()
     _populate_cookies(client)
     with aioresponses() as m:
         m.get(_COLLECTION_RE, payload=_VALID_COLLECTION_JSON)
-        events = await client.get_collection_events(
-            ECOCITO_GARBAGE_COLLECTION_TYPE, 2024
-        )
+        events = await client.get_collection_events("15", 2024)
 
     assert len(events) == 1
     assert isinstance(events[0], CollectionEvent)
@@ -127,9 +179,7 @@ async def test_get_collection_events_session_expired() -> None:
         m.get(_COLLECTION_RE, status=200, body=_HTML_LOGIN_FORM.encode())
         m.post(_LOGIN_URL, status=200, body=_HTML_SUCCESS.encode())
         m.get(_COLLECTION_RE, payload=_VALID_COLLECTION_JSON)
-        events = await client.get_collection_events(
-            ECOCITO_GARBAGE_COLLECTION_TYPE, 2024
-        )
+        events = await client.get_collection_events("15", 2024)
 
     assert len(events) == 1
     assert events[0].location == "12 rue de la Paix"
@@ -144,7 +194,7 @@ async def test_get_collection_events_max_retries() -> None:
             m.get(_COLLECTION_RE, status=200, body=_HTML_LOGIN_FORM.encode())
             m.post(_LOGIN_URL, status=200, body=_HTML_SUCCESS.encode())
         with pytest.raises(EcocitoError):
-            await client.get_collection_events(ECOCITO_GARBAGE_COLLECTION_TYPE, 2024)
+            await client.get_collection_events("15", 2024)
 
 
 async def test_get_collection_events_network_error() -> None:
@@ -157,7 +207,7 @@ async def test_get_collection_events_network_error() -> None:
             exception=aiohttp.ClientConnectionError("network failure"),
         )
         with pytest.raises(CannotConnectError):
-            await client.get_collection_events(ECOCITO_GARBAGE_COLLECTION_TYPE, 2024)
+            await client.get_collection_events("15", 2024)
 
 
 async def test_get_waste_depot_visits_success() -> None:
@@ -173,8 +223,8 @@ async def test_get_waste_depot_visits_success() -> None:
 
 
 async def test_get_addresses() -> None:
-    """Garbage + recycling with overlapping locations → sorted unique addresses."""
-    garbage_json = {
+    """Collections from multiple types with overlapping locations → sorted unique."""
+    type1_json = {
         "data": [
             {
                 "DATE_DONNEE": "2024-03-15T00:00:00",
@@ -188,7 +238,7 @@ async def test_get_addresses() -> None:
             },
         ]
     }
-    recycling_json = {
+    type2_json = {
         "data": [
             {
                 "DATE_DONNEE": "2024-03-16T00:00:00",
@@ -197,11 +247,15 @@ async def test_get_addresses() -> None:
             },
         ]
     }
+    collection_types = [
+        CollectionType(id="15", name="Ordures ménagères"),
+        CollectionType(id="16", name="Recyclage"),
+    ]
     client = _make_client()
     _populate_cookies(client)
     with aioresponses() as m:
-        m.get(_COLLECTION_RE, payload=garbage_json)
-        m.get(_COLLECTION_RE, payload=recycling_json)
-        addresses = await client.get_addresses(2024)
+        m.get(_COLLECTION_RE, payload=type1_json)
+        m.get(_COLLECTION_RE, payload=type2_json)
+        addresses = await client.get_addresses(2024, collection_types)
 
     assert addresses == ["12 rue de la Paix", "20 avenue des Fleurs"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from custom_components.ecocito.client import CollectionEvent
-from custom_components.ecocito.const import ECOCITO_GARBAGE_COLLECTION_TYPE
+from custom_components.ecocito.client import CollectionEvent, CollectionType
 from custom_components.ecocito.coordinator import (
-    GarbageCollectionsDataUpdateCoordinator,
+    CollectionEventsDataUpdateCoordinator,
+    CollectionTypesDataUpdateCoordinator,
 )
 from custom_components.ecocito.errors import (
     CannotConnectError,
@@ -20,39 +20,43 @@ from custom_components.ecocito.errors import (
     InvalidAuthenticationError,
 )
 
+_COLLECTION_TYPE = CollectionType(id="15", name="Ordures ménagères")
+
 
 def _make_event(location: str) -> CollectionEvent:
     return CollectionEvent(
         date=datetime(2024, 3, 15, tzinfo=UTC),
         location=location,
-        type=str(ECOCITO_GARBAGE_COLLECTION_TYPE),
+        type=_COLLECTION_TYPE.id,
         quantity=100.0,
     )
 
 
-async def test_garbage_coordinator_success(
+async def test_collection_events_coordinator_success(
     hass: object, mock_client: MagicMock
 ) -> None:
     """_fetch_data returns events → data is updated correctly."""
     event = _make_event("12 rue de la Paix")
-    mock_client.get_garbage_collections = AsyncMock(return_value=[event])
+    mock_client.get_collection_events = AsyncMock(return_value=[event])
 
-    coordinator = GarbageCollectionsDataUpdateCoordinator(hass, mock_client, 0)
+    coordinator = CollectionEventsDataUpdateCoordinator(
+        hass, mock_client, _COLLECTION_TYPE, 0
+    )
     result = await coordinator._async_update_data()
 
     assert result == [event]
 
 
-async def test_garbage_coordinator_location_filter(
+async def test_collection_events_coordinator_location_filter(
     hass: object, mock_client: MagicMock
 ) -> None:
     """Coordinator with a location filter only returns events for that address."""
     event1 = _make_event("12 rue de la Paix")
     event2 = _make_event("20 avenue des Fleurs")
-    mock_client.get_garbage_collections = AsyncMock(return_value=[event1, event2])
+    mock_client.get_collection_events = AsyncMock(return_value=[event1, event2])
 
-    coordinator = GarbageCollectionsDataUpdateCoordinator(
-        hass, mock_client, 0, location="12 rue de la Paix"
+    coordinator = CollectionEventsDataUpdateCoordinator(
+        hass, mock_client, _COLLECTION_TYPE, 0, location="12 rue de la Paix"
     )
     result = await coordinator._async_update_data()
 
@@ -62,32 +66,78 @@ async def test_garbage_coordinator_location_filter(
 
 async def test_coordinator_cannot_connect(hass: object, mock_client: MagicMock) -> None:
     """Client raises CannotConnectError → UpdateFailed is raised."""
-    mock_client.get_garbage_collections = AsyncMock(
+    mock_client.get_collection_events = AsyncMock(
         side_effect=CannotConnectError("network error")
     )
 
-    coordinator = GarbageCollectionsDataUpdateCoordinator(hass, mock_client, 0)
+    coordinator = CollectionEventsDataUpdateCoordinator(
+        hass, mock_client, _COLLECTION_TYPE, 0
+    )
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
 
 
 async def test_coordinator_invalid_auth(hass: object, mock_client: MagicMock) -> None:
     """Client raises InvalidAuthenticationError → ConfigEntryAuthFailed is raised."""
-    mock_client.get_garbage_collections = AsyncMock(
+    mock_client.get_collection_events = AsyncMock(
         side_effect=InvalidAuthenticationError("bad credentials")
     )
 
-    coordinator = GarbageCollectionsDataUpdateCoordinator(hass, mock_client, 0)
+    coordinator = CollectionEventsDataUpdateCoordinator(
+        hass, mock_client, _COLLECTION_TYPE, 0
+    )
     with pytest.raises(ConfigEntryAuthFailed):
         await coordinator._async_update_data()
 
 
 async def test_coordinator_ecocito_error(hass: object, mock_client: MagicMock) -> None:
     """Client raises EcocitoError → UpdateFailed is raised."""
-    mock_client.get_garbage_collections = AsyncMock(
+    mock_client.get_collection_events = AsyncMock(
         side_effect=EcocitoError("unexpected error")
     )
 
-    coordinator = GarbageCollectionsDataUpdateCoordinator(hass, mock_client, 0)
+    coordinator = CollectionEventsDataUpdateCoordinator(
+        hass, mock_client, _COLLECTION_TYPE, 0
+    )
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+
+async def test_collection_types_coordinator_no_change(
+    hass: object, mock_client: MagicMock
+) -> None:
+    """Types unchanged → no reload triggered, returns types."""
+    known = frozenset(["15", "16"])
+    types = [
+        CollectionType(id="15", name="Ordures ménagères"),
+        CollectionType(id="16", name="Recyclage"),
+    ]
+    mock_client.get_collection_types = AsyncMock(return_value=types)
+
+    coordinator = CollectionTypesDataUpdateCoordinator(hass, mock_client, known)
+    with patch.object(hass, "async_create_task") as mock_create_task:
+        result = await coordinator._async_update_data()
+
+    assert result == types
+    mock_create_task.assert_not_called()
+
+
+async def test_collection_types_coordinator_types_changed(
+    hass: object, mock_client: MagicMock
+) -> None:
+    """Types changed → reload task is created."""
+    known = frozenset(["15", "16"])
+    new_types = [
+        CollectionType(id="15", name="Ordures ménagères"),
+        CollectionType(id="17", name="Déchets verts"),
+    ]
+    mock_client.get_collection_types = AsyncMock(return_value=new_types)
+
+    coordinator = CollectionTypesDataUpdateCoordinator(hass, mock_client, known)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.entry_id = "test_entry_id"
+    with patch.object(hass, "async_create_task") as mock_create_task:
+        result = await coordinator._async_update_data()
+
+    assert result == new_types
+    mock_create_task.assert_called_once()


### PR DESCRIPTION
## Description

Replaces hardcoded collection type IDs (garbage=15, recycling=16) with automatic discovery from the Ecocito web page.

## Changes

### Auto-discovery of collection types
- Scrapes the `Filtres_IdMatiere` HTML selector on `/Usager/Collecte` to list all available types
- A generic `CollectionEventsDataUpdateCoordinator` is created per type×address×year
- `CollectionTypesDataUpdateCoordinator` checks for new types every hour and automatically reloads the integration if the set of types changes

### Icon and translation key mapping
- `COLLECTION_TYPE_HINTS` in `const.py`: list of regex patterns → icon + translation key
- Known types: household waste (🗑️), recycling (♻️), green waste (��), badge (🪪)
- Generic fallback for any other type exposed by the waste collection service

### Stable English entity IDs
- `EcocitoEntity.suggested_object_id()` loads names from `strings.json` to always generate English IDs, regardless of the HA instance language

### Documentation
- README updated: auto-discovery, automatic reload, stable entity IDs, updated dashboard examples

## Commits
- `feat`: auto-discovery + icons + translations + stable IDs + README (Closes #17)
- `fix`: cast `history_years` to int (NumberSelector returns a float)

## Tests
- 25 tests passing
- Ruff clean